### PR TITLE
add datadog host to hipache config

### DIFF
--- a/ansible/roles/hipache/templates/config.json
+++ b/ansible/roles/hipache/templates/config.json
@@ -1,5 +1,7 @@
 {
     "server": {
+        "datadogHost": "{{ ansible_default_ipv4.address }}",
+        "datadogPort": "8125",
         "prependPort": {{ prependIncomingPort | default("false") }},
         "subDomainDepth": {{ subDomainDepth }},
         "accessLog": "/host/access.log",


### PR DESCRIPTION
won't break anything that's deployed today - will just be an extra config value
