### PR TITLE
adding cipher to https options

### DIFF
--- a/ansible/roles/hipache/templates/config.json
+++ b/ansible/roles/hipache/templates/config.json
@@ -23,6 +23,7 @@
         "key": "/etc/ssl/private/{{ domain }}.key",
         "cert": "/etc/ssl/certs/{{ domain }}/{{ domain }}.crt",
         "ca": "/etc/ssl/certs/{{ domain }}/ca.crt",
+        "ciphers": "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:DHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA256:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!SRP:!CAMELLIA",
         "checkForBackend80": {{ httpsCheckForBackend80 | default("false") }}
     },
     "driver": ["redis://{{ redis_host }}:{{ redis_port }}"]


### PR DESCRIPTION
this is mostly for *.runnable.io, removing ciphers that shouldn't be used
