### PR TITLE
Fix Finished Notifications

### DIFF
--- a/ansible/roles/notify/tasks/main.yml
+++ b/ansible/roles/notify/tasks/main.yml
@@ -15,7 +15,6 @@
   local_action: command whoami
   register: local_username
   delegate_to: 127.0.0.1
-  tags: [ notify ]
 
 - name: send rollbar message for deploy
   rollbar_deployment:
@@ -23,5 +22,4 @@
     environment={{node_env}}
     revision={{git_branch}}
     rollbar_user={{local_username.stdout}}
-  tags: [ notify ]
   when: rollbar_token is defined and node_env is defined and git_branch is defined


### PR DESCRIPTION
turns out handlers don't get called unless the task that triggered is _changed_. They were just "okay", but this forced them to be changed and trip the handlers. yay!
