### PR TITLE
fix: add detention to alpha children

### DIFF
--- a/ansible/prod-hosts
+++ b/ansible/prod-hosts
@@ -96,6 +96,7 @@ khronos
 mavis
 optimus
 rabbitmq
+detention
 
 [alpha:vars]
 ansible_ssh_private_key_file=~/.ssh/Test-runnable.pem


### PR DESCRIPTION
was missing `domain` variable - this will fix it
