### PR TITLE
Core dump hax

### DIFF
--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -1,11 +1,12 @@
 ---
 - name: change core dump path
-  lineinfile:
-    backrefs=yes
+  sudo: yes
+  tags: coreDump
+  sysctl:
+    name=kernel.core_pattern
+    reload=yes
     state=present
-    dest=/proc/sys/kernel/core_pattern
-    regexp='*'
-    line=/var/log/core.%h.%e.%t
+    value="/var/log/core.%h.%e.%t"
 
 - name: install aufs with linux-image-extra-{{ ansible_kernel }}
   sudo: yes


### PR DESCRIPTION
we need to set this for core_dumps because of docker, which is why I put it in the docker role.
