### PR TITLE
SAN-2512 Add Redis information to shiva variables

### DIFF
--- a/ansible/group_vars/alpha-shiva.yml
+++ b/ansible/group_vars/alpha-shiva.yml
@@ -9,6 +9,10 @@ npm_version: "2.1.18"
 # Not actually needed, just allows container-kill-start to work
 hosted_ports: ["3000"]
 
+# Needed for the UserData script in shiva
+redis_host: "{{ hostvars[groups['redis'][0]]['ansible_default_ipv4']['address'] }}"
+redis_port: 6379
+
 # container settings
 container_envs: >
   -e DATADOG_HOST={{ datadog_host }}
@@ -21,6 +25,8 @@ container_envs: >
   -e AWS_ACCESS_KEY_ID={{ aws_access_key_id }}
   -e AWS_SECRET_ACCESS_KEY={{ aws_secret_access_key }}
   -e NODE_ENV={{ node_env }}
+  -e REDIS_PORT={{ redis_port }}
+  -e REDIS_IPADDRESS={{ redis_host }}
   --hostname={{ name }}
 
 container_run_opts: "-d -P {{container_envs}}"

--- a/ansible/shiva.yml
+++ b/ansible/shiva.yml
@@ -1,4 +1,5 @@
 ---
+- hosts: redis
 - hosts: rabbitmq
 
 - hosts: shiva


### PR DESCRIPTION
This is needed for a new version of shiva where she sets the redis information for a dock based on NODE_ENV via the user-data script.
