### PR TITLE
Shiva Registry Host

### DIFF
--- a/ansible/group_vars/alpha-shiva.yml
+++ b/ansible/group_vars/alpha-shiva.yml
@@ -27,7 +27,7 @@ container_envs: >
   -e NODE_ENV={{ node_env }}
   -e REDIS_PORT={{ redis_port }}
   -e REDIS_IPADDRESS={{ redis_host }}
-  -e REGISTRY_IP={{ registry_host }}
+  -e REGISTRY_HOST={{ registry_host }}
   --hostname={{ name }}
 
 container_run_opts: "-d -P {{container_envs}}"


### PR DESCRIPTION
Shiva needs to know the registry host so it can set it in the UserData script when starting new docks.
