### PR TITLE
fix: put parens in correct spot

### DIFF
--- a/ansible/group_vars/alpha-sauron.yml
+++ b/ansible/group_vars/alpha-sauron.yml
@@ -1,8 +1,8 @@
 # upstart template variables
 name: sauron
 
-app_name: {{ name }}
-app_repo: "git@github.com:CodeNow/{{ name }}.git"
+app_name: "{{ name }}"
+app_repo: git@github.com:CodeNow/{{ name }}.git
 
 redis_host: "{{ hostvars[groups['redis'][0]]['ansible_default_ipv4']['address'] }}"
 redis_port: 6379


### PR DESCRIPTION
needs to have `"` if a value starts with `{{`
