### PR TITLE
SAN-2758 - change default SG for docks

### DIFF
--- a/ansible/beta-hosts/docks.js
+++ b/ansible/beta-hosts/docks.js
@@ -14,7 +14,7 @@ var params = {
     // Only search for docks in the cluster security group
     {
       Name: 'instance.group-id',
-      Values: ['sg-87ca04e3']
+      Values: ['sg-d6e684b2']
     },
     // Only fetch instances that are tagged as docks
     {


### PR DESCRIPTION
Docks now use a new-fangled security policy. This policy has been in place in Beta all week. Once reviewed, a similar policy will be applied to production (alpha). Improves security of Docker Container services within the Runnable app stack by restricting service connections from only those servers that should be talking to docks.
