### PR TITLE
remove sudo from npm install due to ssh permission issues

### DIFF
--- a/ansible/roles/git_node_service/tasks/main.yml
+++ b/ansible/roles/git_node_service/tasks/main.yml
@@ -25,7 +25,6 @@
     state=absent
 
 - name: npm install {{ app_name }}
-  sudo: yes
   npm:
     path=/opt/runnable/{{ app_name }}
     state=latest


### PR DESCRIPTION
npm install with private repos stops working with sudo.
just do normal npm install
