### PR TITLE
SAN-3095 Automatic Dock Failover

### DIFF
--- a/ansible/group_vars/alpha-khronos.yml
+++ b/ansible/group_vars/alpha-khronos.yml
@@ -8,7 +8,7 @@ npm_version: "2.1.18"
 
 # for cron job
 # this is the list of queues we want to enqueue a job into
-cron_queues: khronos:containers:image-builder:prune khronos:containers:orphan:prune khronos:context-versions:prune-expired khronos:images:prune khronos:weave:prune
+cron_queues: khronos:containers:image-builder:prune khronos:containers:orphan:prune khronos:context-versions:prune-expired khronos:images:prune khronos:weave:prune khronos:docks:obliterate-codenow
 # a nice version of the rabbitmq host
 cron_rabbit_host_address: "{{ rabbit_host_address }}:{{ rabbit_port }}"
 # a quick version of authentication for rabbit for cron


### PR DESCRIPTION
Added khronos:docks:obliterate-codenow queue to the khronos task.
- [x] https://github.com/CodeNow/khronos/pull/43 Merged
- [x] Reviewer 1
- [x] @bkendall
