### PR TITLE
do not copy docker certs unless you are deploying dock

### DIFF
--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -1,12 +1,14 @@
 ---
 - name: create docker cert directory
   sudo: yes
+  when: dock is defined
   file:
     path=/etc/ssl/docker
     state=directory
 
 - name: copy docker certs
   sudo: yes
+  when: dock is defined
   copy:
     src=certs/
     dest=/etc/ssl/docker


### PR DESCRIPTION
we should only copy certs if docker is defined
