### PR TITLE
Include datadog on full stack deploy, run apt-get update first.

### DIFF
--- a/ansible/datadog.yml
+++ b/ansible/datadog.yml
@@ -2,4 +2,5 @@
 - hosts: all
   roles:
   - { role: base_ubuntu }
+  - { role: apt_update }
   - { role: datadog, tags: ["datadog"] }

--- a/ansible/stack.yml
+++ b/ansible/stack.yml
@@ -1,6 +1,9 @@
 ## configure security group policy
 #- include: sg_configure.yml 
 #
+## Install Datadog Agent
+- include: datadog.yml
+#
 ## begin with databases:
 #- include: consul.yml 
 #- include: mongo-navi.yml 


### PR DESCRIPTION
- [x] @podviaznikov 
- [x] @kaushikanurag 

1) datadog is now run as part of full stack deploy; we might want to include it in app deploys individually, or maybe not.
2) datadog deploy as it is run on a per-host basis should trigger apt-get update.
