### PR TITLE
Add ulimits to dock-init.

### DIFF
--- a/ansible/dock-init.yml
+++ b/ansible/dock-init.yml
@@ -13,3 +13,4 @@
   - { role: git_repo, tags: [deploy] }
   - { role: dock-init, tags: [deploy] }
   - { role: consul_value, tags: [deploy, consul_value] }
+  - { role: ulimits, tags: [deploy, ulimits] }


### PR DESCRIPTION
- [x] @bkendall 
- [x] @kaushikanurag 

When called, dock-init will set host limits per the `ulimits` role.
