### PR TITLE
remove consul from sauron

### DIFF
--- a/ansible/group_vars/alpha-sauron.yml
+++ b/ansible/group_vars/alpha-sauron.yml
@@ -1,4 +1,3 @@
-# upstart template variables
 name: sauron
 
 container_image: "registry.runnable.com/runnable/{{ name }}"
@@ -16,11 +15,6 @@ dockerfile_pre_install_commands: [
   "curl -L https://github.com/weaveworks/weave/releases/download/v1.4.1/weave -o {{ weave_path }}",
   "chmod a+x {{ weave_path }}"
 ]
-
-# consul values
-consul_values:
-  - key: "{{ name }}/version"
-    value: "{{ git_branch }}"
 
 container_envs: >
   -e DATADOG_HOST={{ datadog_host_address }}

--- a/ansible/sauron.yml
+++ b/ansible/sauron.yml
@@ -10,4 +10,3 @@
   - { role: docker_client }
   - { role: builder, tags: [build] }
   - { role: container_kill_start, tags: [deploy] }
-  - { role: consul_value, tags: [deploy, consul_value] }


### PR DESCRIPTION
we should not populate consul with sauron. 
sauron  does not live on the docks anymore, therefore we do not need its version (this was used by dock-init to pull the right version down)
