### PR TITLE
SAN-3559; Optimus Node 4

### DIFF
--- a/ansible/group_vars/alpha-optimus.yml
+++ b/ansible/group_vars/alpha-optimus.yml
@@ -4,7 +4,7 @@ container_image: "registry.runnable.com/runnable/{{ name }}"
 container_tag: "{{ git_branch }}"
 repo: "git@github.com:CodeNow/{{ name }}.git"
 hosted_ports: ["{{ optimus_port }}"]
-node_version: "0.10.38"
+node_version: "4.3.2"
 npm_version: "2.8.3"
 
 # for redis


### PR DESCRIPTION
Updates Optimus group variables to use node 4.

**Reviewers**
- [x] @und1sk0 

**Tests**
- [x] Tested on gamma with `es6` branch of optimus
