### PR TITLE
Fix: Missing Khronos Daily Cleanup Script

### DIFF
--- a/ansible/roles/khronos/tasks/main.yml
+++ b/ansible/roles/khronos/tasks/main.yml
@@ -17,6 +17,7 @@
     job: /opt/runnable/{{ item.script }} >> /var/log/{{ item.script }}.log 2>&1
     minute: "{{ item.minute | default('*') }}"
     hour: "{{ item.hour | default('*') }}"
+    state: "{{ item.state | default('present') }}"
   with_items:
   - name: Khronos CLI - Daily Cleanup
     minute: 13
@@ -25,6 +26,7 @@
   - name: Khronos CLI - Canary
     minute: "*/5"
     script: build-canary.sh
+    state: "{% if node_env == 'production-delta' %}present{% else %}absent{% endif %}"
 
 - name: make directory for mongo certificates
   become: yes


### PR DESCRIPTION
The daily cleanup script was being overwritten by the canary test because they had the same name. Giving each unique names now and condensing them into one task with items.
#### Reviewers
- [x] @anand  
#### Tests
- [x] tested (and confirmed) on gamma, epsilon, and delta by @bkendall
