### PR TITLE
API: communicate w/ MongoDB using TLS

### DIFF
--- a/ansible/api-core.yml
+++ b/ansible/api-core.yml
@@ -19,5 +19,6 @@
   - { role: redis_key, tags: [ setup, redis_key ] }
   - { role: builder, tags: [ build ] }
   - { role: docker_client }
+  - { role: tls-client, tls_service: mongodb, tags: [ tls ] }
   - { role: datadog, tags: [ datadog ] }
   - { role: container_start }

--- a/ansible/group_vars/alpha-api-base.yml
+++ b/ansible/group_vars/alpha-api-base.yml
@@ -1,9 +1,9 @@
 container_tag: "{{ git_branch }}"
 
-node_version: "0.10.38"
-npm_version: "2.8.3"
+node_version: 0.10.38
+npm_version: 2.8.3
 
-repo: "git@github.com:CodeNow/api.git"
+repo: git@github.com:CodeNow/api.git
 
 # for sendGrid
 sendgrid_key: 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
@@ -26,8 +26,11 @@ api_base_container_envs: >
   -e KRAIN_PORT={{ krain_port }}
   -e MAVIS_HOST=http://{{ mavis_hostname }}:80
   -e MIXPANEL_APP_ID={{ api_mixpanel_app_id }}
-  -e MONGO=mongodb://{{ api_mongo_auth }}@{{ mongo_hosts }}/{{ api_mongo_database }}
+  -e MONGO_CACERT=/opt/ssl/mongodb-client/ca.pem
+  -e MONGO_CERT=/opt/ssl/mongodb-client/cert.pem
+  -e MONGO_KEY=/opt/ssl/mongodb-client/key.pem
   -e MONGO_REPLSET_NAME={{ api_mongo_replset_name }}
+  -e MONGO=mongodb://{{ api_mongo_auth }}@{{ mongo_hosts }}/{{ api_mongo_database }}
   -e NAVI_HOST=http://{{ navi_host_address }}:{{ navi_port }}
   -e NEO4J={{ api_neo4j_protocol }}{{ api_neo4j_auth }}@{{ neo4j_host_address }}:{{ api_neo4j_port }}
   -e NEW_RELIC_APP_NAME={{ api_new_relic_app_name }}

--- a/ansible/group_vars/alpha-api.yml
+++ b/ansible/group_vars/alpha-api.yml
@@ -1,12 +1,12 @@
-name: "api"
+name: api
 
 container_image: registry.runnable.com/runnable/{{ name }}
 
-hosted_ports: ["{{ api_port }}"]
+hosted_ports: [ "{{ api_port }}" ]
 
 # for redis
-redis_key: "frontend:{{ api_hostname }}"
-is_redis_update_required: 'yes'
+redis_key: frontend:{{ api_hostname }}
+is_redis_update_required: yes
 
 # for container settings
 container_envs: >
@@ -18,4 +18,5 @@ container_run_opts: >
   -d
   -P
   -v /opt/ssl/docker/{{ name }}:/etc/ssl/docker:ro
+  -v /opt/ssl/mongodb-client:/opt/ssl/mongodb-client:ro
   {{ container_envs }}

--- a/ansible/group_vars/alpha-socket-server.yml
+++ b/ansible/group_vars/alpha-socket-server.yml
@@ -1,12 +1,12 @@
-name: "api-socket-server"
+name: api-socket-server
 
 container_image: registry.runnable.com/runnable/{{ name }}
 
-hosted_ports: ["{{ api_port }}"]
+hosted_ports: [ "{{ api_port }}" ]
 
 # for redis
-redis_key: "frontend:{{ api_socket_server_hostname }}"
-is_redis_update_required: 'yes'
+redis_key: frontend:{{ api_socket_server_hostname }}
+is_redis_update_required: yes
 
 # for container settings
 container_envs: >
@@ -18,4 +18,5 @@ container_run_opts: >
   -d
   -P
   -v /opt/ssl/docker/{{ name }}:/etc/ssl/docker:ro
+  -v /opt/ssl/mongodb-client:/opt/ssl/mongodb-client:ro
   {{ container_envs }}

--- a/ansible/group_vars/alpha-workers.yml
+++ b/ansible/group_vars/alpha-workers.yml
@@ -1,4 +1,4 @@
-name: "api-worker"
+name: api-worker
 
 container_image: registry.runnable.com/runnable/{{ name }}
 
@@ -12,4 +12,5 @@ container_run_opts: >
   -h {{ name }}
   -d
   -v /opt/ssl/docker/{{ name }}:/etc/ssl/docker:ro
+  -v /opt/ssl/mongodb-client:/opt/ssl/mongodb-client:ro
   {{ container_envs }}

--- a/ansible/roles/tls-client/meta/main.yml
+++ b/ansible/roles/tls-client/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: tls-client-cert }

--- a/ansible/roles/tls-client/tasks/main.yml
+++ b/ansible/roles/tls-client/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+- name: make directory for client certificates
+  tags: [ tls_client ]
+  become: yes
+  file:
+    dest: /opt/ssl/{{ tls_service }}-client
+    state: directory
+
+- name: put client CA in place for service
+  tags: [ tls_client ]
+  become: yes
+  copy:
+    dest: /opt/ssl/{{ tls_service }}-client/ca.pem
+    content: "{{ new_client_certs.data.issuing_ca }}"
+    mode: 0400
+
+- name: put client certificate in place for service
+  tags: [ tls_client ]
+  become: yes
+  copy:
+    dest: /opt/ssl/{{ tls_service }}-client/cert.pem
+    content: "{{ new_client_certs.data.certificate }}"
+    mode: 0400
+
+- name: put client private key in place for service
+  tags: [ tls_client ]
+  become: yes
+  copy:
+    dest: /opt/ssl/{{ tls_service }}-client/key.pem
+    content: "{{ new_client_certs.data.private_key }}"
+    mode: 0400

--- a/ansible/socket-server.yml
+++ b/ansible/socket-server.yml
@@ -19,5 +19,6 @@
   - { role: redis_key, tags: [ setup, redis_key ] }
   - { role: builder, tags: [ build ] }
   - { role: docker_client }
+  - { role: tls-client, tls_service: mongodb, tags: [ tls ] }
   - { role: datadog, tags: [ datadog ] }
   - { role: container_start }

--- a/ansible/workers.yml
+++ b/ansible/workers.yml
@@ -18,5 +18,6 @@
     tags: [ notify ]
   - { role: builder, tags: [ build ] }
   - { role: docker_client }
+  - { role: tls-client, tls_service: mongodb, tags: [ tls ] }
   - { role: datadog, tags: [ datadog ] }
   - { role: container_kill_start }


### PR DESCRIPTION
API needs some `tls-client`. Here it is.

Reviewers:
- [x] @rsandor

Merge this after https://github.com/CodeNow/api/pull/1424
