### PR TITLE
adding consul monitoring with datadog

### DIFF
--- a/ansible/consul.yml
+++ b/ansible/consul.yml
@@ -6,5 +6,6 @@
   roles:
   - { role: notify, tags: notify }
   - { role: database }
+  - { role: datadog, tags: [ datadog ] }
   - { role: consul }
   - { role: container_kill_start }

--- a/ansible/roles/consul/tasks/main.yml
+++ b/ansible/roles/consul/tasks/main.yml
@@ -31,3 +31,20 @@
     - ca.pem
     - cert.pem
     - key.pem
+
+- name: add datadog monitoring
+  become: true
+  tags: datadog
+  template:
+    src: datadog-consul.yaml.j2
+    dest: /etc/dd-agent/conf.d/consul.yaml
+    mode: 0444
+    owner: root
+    group: root
+
+- name: restart datadog agent
+  become: true
+  tags: datadog
+  service:
+    name: datadog-agent
+    state: restarted

--- a/ansible/roles/consul/templates/consul.json.j2
+++ b/ansible/roles/consul/templates/consul.json.j2
@@ -17,6 +17,7 @@
   "recursors": [
     "8.8.8.8"
   ],
+  "dogstatsd_addr": "{{ ansible_default_ipv4.address }}:{{ datadog_port }}",
   {% if consul_host_address != ansible_default_ipv4.address %}
     "retry_join": [
       "{{ consul_host_address }}"

--- a/ansible/roles/consul/templates/datadog-consul.yaml.j2
+++ b/ansible/roles/consul/templates/datadog-consul.yaml.j2
@@ -1,0 +1,22 @@
+init_config:
+
+instances:
+  # Where your Consul HTTP Server Lives
+  - url: http://{{ ansible_default_ipv4.address }}:8500
+
+    # Whether to perform checks against the Consul service Catalog
+    # catalog_checks: yes
+
+    # Whether to enable new leader checks from this agent
+    # Note: if this is set on multiple agents in the same cluster
+    # you will receive one event per leader change per agent
+    new_leader_checks: {% if consul_host_address == ansible_default_ipv4.address %}yes{% else %}no{% endif %}
+
+    # Services to restrict catalog querying to
+    # The default settings query up to 50 services. So if you have more than
+    # this many in your Consul service catalog, you will want to fill in the
+    # whitelist
+    # service_whitelist:
+    #   - zookeeper
+    #   - haproxy
+    #   - redis


### PR DESCRIPTION
- consul needs config to output stats to datadog
- datadog needs to be installed on the consul boxes and configured to monitor consul
### Reviewers
- [x] @anandkumarpatel 
- [x] @und1sk0 
### Integration Test
- [x] Tested on _epsilon_ and _gamma_ by @bkendall
- [x] See data in [datadog](https://app.datadoghq.com/screen/70256/consul-information?tpl_var_environment=gamma)
