### PR TITLE
SAN-4091; Swarm-manager Dedicated Instance

### DIFF
--- a/ansible/delta-hosts/hosts
+++ b/ansible/delta-hosts/hosts
@@ -99,7 +99,7 @@ delta-registry
 delta-dock-services
 
 [swarm-manager]
-delta-dock-services
+delta-swarm-manager
 
 [metis]
 delta-app-services

--- a/ssh/config
+++ b/ssh/config
@@ -197,6 +197,9 @@ Host delta-mongo-c
 Host delta-navi
   ProxyCommand ssh -q ubuntu@delta-bastion nc 10.8.6.41 22
 
+Host delta-swarm-manager
+  ProxyCommand ssh -q ubuntu@delta-bastion nc 10.8.4.40 22
+
 ################################################################################
 # Epsilon
 ################################################################################


### PR DESCRIPTION
- Added new host `delta-swarm-manager` (i-c82fcd0e)
- Changed swarm-manager to use new dedicated `m4.4xlarge` instance in delta.
#### Reviewers
- [x] @anandkumarpatel 
- [x] @bkendall 
- [x] @und1sk0 (AWS instance creation review)
#### Tests
- [x] Tested deploy works on `delta` (only run swarm-manager)
#### Deployment (post-merge)

The following services need to be redeployed to switch to the new swarm:
- [x] swarm-manager
- [ ] api
- [ ] khronos
- [ ] mavis
- [ ] docker-listener
- [ ] sauron
- [ ] Remove old `swarm-manager` from `delta-dock-services`

List was calculated via the following:

``` bash
grep '\- hosts: swarm-manager' ansible/*.yml
```
