### PR TITLE
Fix docker-listener and sauron for new swarm manager host

### DIFF
--- a/ansible/docker-listener.yml
+++ b/ansible/docker-listener.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: rabbitmq
 - hosts: consul
+- hosts: swarm-manager
 
 - hosts: docker-listener
   vars_files:

--- a/ansible/sauron.yml
+++ b/ansible/sauron.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: rabbitmq
 - hosts: consul
+- hosts: swarm-manager
 
 - hosts: sauron
   vars_files:


### PR DESCRIPTION
- Added swarm manager host to docker listener and sauron
#### Reviewers
- [x] @bkendall 
#### Deployment (post-merge)

> Ensure that all environments have the given changes.
- [ ] api
- [ ] khronos
- [ ] mavis
- [ ] docker-listener
- [ ] sauron
- [ ] Remove old `swarm-manager` from `delta-dock-services`
