### PR TITLE
enforce permissions and clear formatting

### DIFF
--- a/ansible/roles/loggly/files/50-default.conf
+++ b/ansible/roles/loggly/files/50-default.conf
@@ -1,0 +1,68 @@
+#  Default rules for rsyslog.
+#
+#			For more information see rsyslog.conf(5) and /etc/rsyslog.conf
+
+#
+# First some standard log files.  Log by facility.
+#
+auth,authpriv.*			/var/log/auth.log
+*.*;auth,authpriv.none		-/var/log/syslog
+#cron.*				/var/log/cron.log
+#daemon.*			-/var/log/daemon.log
+kern.*				-/var/log/kern.log
+#lpr.*				-/var/log/lpr.log
+mail.*				-/var/log/mail.log
+#user.*				-/var/log/user.log
+
+#
+# Logging for the mail system.  Split it up so that
+# it is easy to write scripts to parse these files.
+#
+#mail.info			-/var/log/mail.info
+#mail.warn			-/var/log/mail.warn
+mail.err			/var/log/mail.err
+
+#
+# Logging for INN news system.
+#
+news.crit			/var/log/news/news.crit
+news.err			/var/log/news/news.err
+news.notice			-/var/log/news/news.notice
+
+#
+# Some "catch-all" log files.
+#
+#*.=debug;\
+#	auth,authpriv.none;\
+#	news.none;mail.none	-/var/log/debug
+#*.=info;*.=notice;*.=warn;\
+#	auth,authpriv.none;\
+#	cron,daemon.none;\
+#	mail,news.none		-/var/log/messages
+
+#
+# Emergencies are sent to everybody logged in.
+#
+*.emerg                                :omusrmsg:*
+
+#
+# I like to have messages displayed on the console, but only on a virtual
+# console I usually leave idle.
+#
+#daemon,mail.*;\
+#	news.=crit;news.=err;news.=notice;\
+#	*.=debug;*.=info;\
+#	*.=notice;*.=warn	/dev/tty8
+
+# The named pipe /dev/xconsole is for the `xconsole' utility.  To use it,
+# you must invoke `xconsole' with the `-file' option:
+# 
+#    $ xconsole -file /dev/xconsole [...]
+#
+# NOTE: adjust the list below, or you'll go crazy if you have a reasonably
+#      busy site..
+#
+daemon.*;mail.*;\
+	news.err;\
+	*.=debug;*.=info;\
+	*.=notice;*.=warn	|/dev/xconsole

--- a/ansible/roles/loggly/files/rsyslog.conf
+++ b/ansible/roles/loggly/files/rsyslog.conf
@@ -38,7 +38,7 @@ $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 # Runnable JSON logging format
 # Creates an "output formatter" template that accepts as input JSON and prints it out without any further processing ("raw JSON").
 # The formatting around the %msg% string is as such: start printing at the second character "2" until the end of the line "$" using the raw JSON format type.
-$template RunnableJSON,"%msg:2:$:jsonr%\n"
+$template RunnableJSON,"%msg:2:$:%\n"
 
 # Filter duplicated messages
 $RepeatedMsgReduction on

--- a/ansible/roles/loggly/tasks/main.yml
+++ b/ansible/roles/loggly/tasks/main.yml
@@ -9,6 +9,15 @@
     cache_valid_time=604800
     install_recommends=yes
 
+- name: copy rsyslog default config
+  tags: loggly
+  become: true
+  copy:
+    src=50-default.conf
+    dest=/etc/rsyslog.d/50-default.conf
+    owner=syslog
+    group=syslog
+
 - name: copy loggly TLS config
   tags: loggly
   become: true

--- a/ansible/roles/loggly/templates/21-output-syslog.conf.j2
+++ b/ansible/roles/loggly/templates/21-output-syslog.conf.j2
@@ -2,7 +2,7 @@ $WorkDirectory /var/spool/rsyslog
 
 # Rotate per hour
 $template RotateHourly_{{ name }},"{{ app_log_dir }}/%$YEAR%/%$MONTH%/%$DAY%/%$HOUR%/{{ name }}.log"
-if $msg contains '{{ name }}' and $syslogfacility-text == 'local7' then { action (type="omfile" DynaFile="RotateHourly_{{ name }}" template="RunnableJSON") }
+if $msg contains '{{ name }}' and $syslogfacility-text == 'local7' then { action (type="omfile" DynaFile="RotateHourly_{{ name }}" template="RunnableJSON" dirCreateMode="0755" FileCreateMode="0644") }
 
 # Loggly: Add a tag for {{ name }} events
 $template LogglyFormat_{{ name }},"<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %msgid% [{{ loggly_token }}@41058 tag=\"runnable\" tag=\"{{ node_env }}\"] %msg%\n"


### PR DESCRIPTION
- Do not need to format %msg% (and "jsonr" directive is invalid anyway)
- For some reason the default rsyslog file was never in Ansible, and was being removed from hosts, putting it in to make sure that normal system messages go to the right places.
#### Dependencies
- [x] list dependencies - no real dependencies but builds on devops-scripts tag `v1.0.1`.
#### Reviewers
- [x] @rsandor 
- [x] @anandkumarpatel 
#### Tests

> Test any modifications on one of our environments.
- [x] tested on epsilon by @und1sk0
#### Deployment (post-merge)

> Ensure that all environments have the given changes.
- [ ] deployed to epsilon
- [ ] deployed to gamma
- [ ] deployed to delta
