### PR TITLE
Add image-builder-prune to cron list

### DIFF
--- a/ansible/group_vars/alpha-khronos.yml
+++ b/ansible/group_vars/alpha-khronos.yml
@@ -12,6 +12,7 @@ main_cron_queues: "\
   khronos:containers:orphan:prune \
   khronos:context-versions:prune-expired \
   khronos:images:prune \
+  khronos:containers:image-builder:prune \
   khronos:weave:prune"
 
 canary_cron_queues: "\


### PR DESCRIPTION
This enables the 'khronos:containers:image-builder:prune' job to be called on schedule with the other cron jobs.  
- [x] @bkendall 
- [x] @anandkumarpatel
