### PR TITLE
Pass consul to docker-listener

### DIFF
--- a/ansible/group_vars/alpha-docker-listener.yml
+++ b/ansible/group_vars/alpha-docker-listener.yml
@@ -9,6 +9,7 @@ npm_version: "2.14.7"
 restart_policy: "always"
 
 container_envs: >
+  -e CONSUL_HOST={{ consul_host_address }}:{{ consul_api_port }}
   -e DATADOG_HOST={{ datadog_host_address }}
   -e DATADOG_PORT={{ datadog_port }}
   -e DOCKER_CERT_PATH=/etc/ssl/docker


### PR DESCRIPTION
# Docker listener uses swarmerode

Swarmerode needs `CONSUL_HOST`
#### Reviewers
- [x] @anandkumarpatel 
- [ ] _person_2_
#### Deployment (post-merge)

> Ensure that all environments have the given changes.
- [x] deployed to epsilon
- [ ] deployed to gamma
- [ ] deployed to delta
