### PR TITLE
Fix how we pass runnabot access token env to pheidi

### DIFF
--- a/ansible/epsilon-hosts/variables
+++ b/ansible/epsilon-hosts/variables
@@ -60,6 +60,7 @@ palantiri_rollbar_key=f675e9090d6f483ca4e742af2c7f2f83
 pheidi_mongo_auth=api:3f5210b8-8fe3-11e5-8e62-07b6eff19ecb
 pheidi_mongo_database=epsilon
 pheidi_mongo_replset_name=epsilon
+pheidi_runnabot_tokens=ff3d259c5d988badbb692cc400998e46cdd5f1fc
 
 [sauron:vars]
 sauron_rollbar_key=83157ae2d50d4b6398e404c0b9978d26

--- a/ansible/gamma-hosts/variables
+++ b/ansible/gamma-hosts/variables
@@ -60,6 +60,7 @@ palantiri_rollbar_key=f675e9090d6f483ca4e742af2c7f2f83
 pheidi_mongo_auth=api:3f5210b8-8fe3-11e5-8e62-07b6eff19ecb
 pheidi_mongo_database=gamma
 pheidi_mongo_replset_name=gamma
+pheidi_runnabot_tokens=ff3d259c5d988badbb692cc400998e46cdd5f1fc
 
 [sauron:vars]
 sauron_rollbar_key=83157ae2d50d4b6398e404c0b9978d26

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -142,7 +142,6 @@ palantiri_rollbar_token: f675e9090d6f483ca4e742af2c7f2f83
 
 # pheidi
 pheidi_rollbar_token: 6fc422ac645441bea7f6f14853eb01ab
-pheidi_runnabot_tokens: ff3d259c5d988badbb692cc400998e46cdd5f1fc
 
 # rabbit
 rabbit_host_address: "{{ hostvars[groups['rabbitmq'][0]]['ansible_default_ipv4']['address'] }}"


### PR DESCRIPTION
 Fix passing ot tokens to pheidi

Each env explicitly defines token. Otherwise `group_vars/all.yml` overwrites everything
#### Reviewers
- [x] @und1sk0
- [x] @anandkumarpatel
  #### Tests

> Test any modifications on one of our environments.
- [ ] tested on _environment_ by _someone_
#### Deployment (post-merge)

> Ensure that all environments have the given changes.
- [ ] deployed to epsilon
- [ ] deployed to gamma
- [ ] deployed to delta
