### PR TITLE
This broke when we changed "lineinfile" to "copy"

### DIFF
--- a/ansible/roles/dock-init/tasks/main.yml
+++ b/ansible/roles/dock-init/tasks/main.yml
@@ -4,7 +4,7 @@
 
 - name: create vault auth directory
   tags: vault_files
-  becore: true
+  become: true
   file:
     dest="/opt/runnable/dock-init/consul-resources/vault/{{ node_env }}"
     state=directory


### PR DESCRIPTION
- create vault values dir, because copy will not
#### Reviewers
- [x] @rsandor
- [x] @bkendall
#### Tests

> Test any modifications on one of our environments.
- [x] tested on delta by @und1sk0
#### Deployment (post-merge)

> Ensure that all environments have the given changes.
- [ ] deployed to epsilon
- [ ] deployed to gamma
- [ ] deployed to delta
