### PR TITLE
New one hour aws mount

### DIFF
--- a/ansible/vault-values.yml
+++ b/ansible/vault-values.yml
@@ -8,17 +8,17 @@
       become: true
       apt: package=python-httplib2 state=present
 
-    # - name: put values into vault
-    #   run_once: true
-    #   when: write_values is defined
-    #   uri:
-    #     method=PUT
-    #     url=http://{{ ansible_default_ipv4.address }}:8200/v1/{{ item.key }}
-    #     HEADER_X-Vault-Token="{{ vault_auth_token }}"
-    #     body_format=json
-    #     body='{{ item.data | to_json }}'
-    #     status_code=200,204
-    #   with_items: "{{ vault_seed_values }}"
+    - name: put values into vault
+      run_once: true
+      when: write_values is defined
+      uri:
+        method=PUT
+        url=http://{{ ansible_default_ipv4.address }}:8200/v1/{{ item.key }}
+        HEADER_X-Vault-Token="{{ vault_auth_token }}"
+        body_format=json
+        body='{{ item.data | to_json }}'
+        status_code=200,204
+      with_items: "{{ vault_seed_values }}"
 
     - name: check for aws backend in vault
       run_once: true


### PR DESCRIPTION
Basically, we're going to make a new mount that has a ttl of one hour. Vault does _not_ support custom ttls (and consul-template definitely doesn't), so the only way to have better ttls is to put them on seperate mounts.

dock-init will basically read from `aws_1h/creds/dock-init` rather than `aws/creds/dock-init`.

ends up looking like this:

```
/ # vault mounts
Path        Type       Default TTL  Max TTL  Description
aws/        aws        system       system
aws_1h/     aws        3600         3600
```
#### Reviewers
- [x] @ananadkumarpatel
#### Tests

> Test any modifications on one of our environments.
- [x] tested on _gamma_ by _@bkendall_
#### Deployment (post-merge)

> Ensure that all environments have the given changes.
- [x] deployed to epsilon
- [x] deployed to gamma
- [x] deployed to delta
