### PR TITLE
Bullocks

### DIFF
--- a/ansible/roles/loggly/files/21-rotated-docker.conf
+++ b/ansible/roles/loggly/files/21-rotated-docker.conf
@@ -1,10 +1,12 @@
 $WorkDirectory /var/spool/rsyslog
 
 # Rotate per hour
+$ActionQueueType Direct
 $template RotateHourly_docker_engine,"/var/log/runnable/%$YEAR%/%$MONTH%/%$DAY%/%$HOUR%/docker_engine.log"
 if $syslogtag contains 'docker_engine' and $syslogfacility-text == 'local7' then { action (type="omfile" DynaFile="RotateHourly_docker_engine" template="RunnableJSON" dirCreateMode="0755" FileCreateMode="0644") }
 
 # Loggly: Add a tag for docker_engine events
-$template LogglyFormat_docker_engine,"<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %syslogtag% [f673760d-e0b3-4a93-a15e-2862ea074f91@41058 tag=\"runnable\" tag=\"production-epsilon\"] %msg%\n"
+$ActionQueueType LinkedList
+$template LogglyFormat_docker_engine,"<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %syslogtag% [{{ loggly_token }}@41058 tag=\"runnable\" tag=\"{{ node_env }}\"] %msg%\n"
 if $syslogtag contains 'docker_engine' and $syslogfacility-text == 'local7' then @@logs-01.loggly.com:6514;LogglyFormat_docker_engine
 if $syslogtag contains 'docker_engine' and $syslogfacility-text == 'local7' then stop


### PR DESCRIPTION
- fix syntax for docker_engine logging template
#### Reviewers
- [ ] @anandkumarpatel 
#### Tests

> Test any modifications on one of our environments.
- [ ] tested on `epsilon` by @und1sk0
#### Deployment (post-merge)

> Ensure that all environments have the given changes.
- [ ] deployed to epsilon
- [ ] deployed to gamma
- [ ] deployed to delta
