### PR TITLE
add 1 year backend for aws

### DIFF
--- a/ansible/roles/vault/tasks/main.yml
+++ b/ansible/roles/vault/tasks/main.yml
@@ -21,6 +21,7 @@
     recurse=yes
 
 - name: copy vault config
+  tags: [ deploy ]
   become: true
   template:
     src=vault.hcl

--- a/ansible/roles/vault/templates/vault.hcl
+++ b/ansible/roles/vault/templates/vault.hcl
@@ -19,3 +19,5 @@ listener "tcp" {
   tls_cert_file = "/opt/vault/server/cert.pem"
   tls_key_file = "/opt/vault/server/key.pem"
 }
+
+max_lease_ttl = "8760h"

--- a/ansible/vault-values.yml
+++ b/ansible/vault-values.yml
@@ -61,8 +61,8 @@
       with_items:
         - type: "aws"
           config:
-            default_lease_ttl: "31536000s" # 1 year, in seconds
-            max_lease_ttl: "31536000s" # 1 year, in seconds
+            default_lease_ttl: "8760h" # 1 year, in hours
+            max_lease_ttl: "8760h" # 1 year, in hours
 
     - name: configure 1h aws root credentials
       run_once: true

--- a/ansible/vault.yml
+++ b/ansible/vault.yml
@@ -10,6 +10,7 @@
 
   tasks:
   - name: get seal status
+    tags: [ deploy ]
     uri:
       method=GET
       url=http://{{ ansible_default_ipv4.address }}:8200/v1/sys/seal-status
@@ -18,6 +19,7 @@
     register: seal_status
 
   - name: unseal vault
+    tags: [ deploy ]
     when: seal_status.json.sealed
     uri:
       method=PUT


### PR DESCRIPTION
When running vault values, create the 1 year ttl mount for AWS.
#### Reviewers
- [x] @anandkumarpatel
#### Tests

> Test any modifications on one of our environments.
- [x] tested on _gamma_ by @bkendall
#### Deployment (post-merge)

> Ensure that all environments have the given changes.
- [x] deployed to epsilon
- [x] deployed to gamma
- [x] deployed to delta
