### PR TITLE
always limit memory to 1g for kill start containers

### DIFF
--- a/ansible/roles/container_kill_start/tasks/main.yml
+++ b/ansible/roles/container_kill_start/tasks/main.yml
@@ -68,9 +68,7 @@
   become: yes
   command: |
     docker run \
-    {% if memory_hard_limit is defined %}
-      --memory {{ memory_hard_limit | default ( "1g" ) }} \
-    {% endif %}
+    --memory {{ memory_hard_limit | default ( "1g" ) }} \
     --log-driver={{ log_driver }} \
     {% if log_driver == "syslog" %}
       --log-opt syslog-facility={{ log_facility }} \


### PR DESCRIPTION
- removed defined check for memory limit on container kill start
#### Dependencies
- [ ] list dependencies (eg, PR from another branch or repo; tags or versions required prior to deployment)
#### Reviewers
- [x] _person_1_
- [ ] _person_2_
#### Tests

> Test any modifications on one of our environments.
- [x] tested on _environment_ by _someone_
#### Deployment (post-merge)

> Ensure that all environments have the given changes.
- [ ] deployed to epsilon
- [ ] deployed to gamma
- [ ] deployed to delta
