### PR TITLE
Revert "update api to use node 4.2.2 and npm 2.14.7"

### DIFF
--- a/ansible/group_vars/alpha-api-base.yml
+++ b/ansible/group_vars/alpha-api-base.yml
@@ -1,7 +1,7 @@
 container_tag: "{{ git_branch }}"
 
-node_version: 4.2.2
-npm_version: 2.14.7
+node_version: 0.10.38
+npm_version: 2.8.3
 
 repo: git@github.com:CodeNow/api.git
 restart_policy: always


### PR DESCRIPTION
Reverts CodeNow/devops-scripts#526
