### PR TITLE
Add NPM token and BIG_POPPA_HOST

### DIFF
--- a/ansible/group_vars/alpha-pheidi.yml
+++ b/ansible/group_vars/alpha-pheidi.yml
@@ -9,7 +9,16 @@ npm_version: "2.14.7"
 # for sendGrid
 sendgrid_key: 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
 
+dockerfile_enviroment: [
+  "NPM_TOKEN {{ npm_token }}"
+]
+
+dockerfile_pre_install_commands: [
+   "echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc"
+]
+
 container_envs: >
+  -e BIG_POPPA_HOST=http://{{ big_poppa_host_address }}:{{ big_poppa_port }}
   -e DATADOG_HOST={{ datadog_host_address }}
   -e DATADOG_PORT={{ datadog_port }}
   -e DOMAIN={{ domain }}


### PR DESCRIPTION
### What this PR does
- Add `NPM_TOKEN` in order to be able to install `big-poppa-client`
- Add `BIG_POPPA_HOST`
#### Reviewers
- [x] @und1sk0
- [x] @anandkumarpatel
#### Tests

> Test any modifications on one of our environments.
- [x] tested on `gamma` by `@thejsj`
#### Deployment (post-merge)

> Ensure that all environments have the given changes.
- [ ] deployed to epsilon
- [x] deployed to gamma
- [ ] deployed to delta
