### PR TITLE
Lock services node versions

### DIFF
--- a/ansible/group_vars/alpha-drake-http.yml
+++ b/ansible/group_vars/alpha-drake-http.yml
@@ -4,7 +4,7 @@ container_image: registry.runnable.com/runnable/{{ name }}
 container_tag: "{{ git_branch }}"
 hosted_ports: ["{{ drake_port }}"]
 repo: "git@github.com:CodeNow/drake.git"
-node_version: lts
+node_version: "4.2.2"
 npm_version: 2
 
 # Exposes drake (heh)

--- a/ansible/group_vars/alpha-drake-worker.yml
+++ b/ansible/group_vars/alpha-drake-worker.yml
@@ -3,7 +3,7 @@ name: drake-worker
 container_image: registry.runnable.com/runnable/{{ name }}
 container_tag: "{{ git_branch }}"
 repo: "git@github.com:CodeNow/drake.git"
-node_version: lts
+node_version: "4.2.2"
 npm_version: 2
 
 # for container settings

--- a/ansible/group_vars/alpha-khronos.yml
+++ b/ansible/group_vars/alpha-khronos.yml
@@ -3,7 +3,7 @@ name: khronos
 container_image: registry.runnable.com/runnable/{{ name }}
 container_tag: "{{ git_branch }}"
 repo: "git@github.com:CodeNow/{{ name }}.git"
-node_version: lts
+node_version: "4.2.2"
 npm_version: 2
 
 dockerfile_enviroment: [

--- a/ansible/group_vars/alpha-swarm-manager-metrics.yml
+++ b/ansible/group_vars/alpha-swarm-manager-metrics.yml
@@ -4,7 +4,7 @@ name: swarm-cloudwatch-reporter
 repo: git@github.com:CodeNow/furry-cactus.git
 container_image: registry.runnable.com/runnable/{{ name }}
 container_tag: "{{ git_branch }}"
-node_version: lts
+node_version: "4.2.2"
 npm_version: 3
 do_not_push: true
 


### PR DESCRIPTION
LTS version changed recently from 4 to 6.
We shouldn't upgrade automatically without testing code.
We need to lock our version and upgrade whenever we are ready.
