### PR TITLE
Moved the cream publishable key to all.yml

### DIFF
--- a/ansible/delta-hosts/variables
+++ b/ansible/delta-hosts/variables
@@ -52,7 +52,6 @@ cream_worker_rollbar_token=87924b881c3143968cdb059fe41acbc3
 cream_intercom_key=173c1b366d11a3ef0f641c6b3327914368e67095
 cream_intercom_id=wqzm3rju
 cream_stripe_secret_key=sk_live_ZWLZtu5rxJ0ylSoF8xrHtNOw
-cream_stripe_publishable_key=pk_live_5yYYZlYIwY3LwvKFaXY0jNlm
 
 [docks:vars]
 docker_config=docks

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -88,6 +88,7 @@ consul_https_port: 8501
 # cream
 cream_port: 8899
 cream_host_address: "{{ hostvars[groups['cream'][0]]['ansible_default_ipv4']['address'] }}"
+cream_stripe_publishable_key: pk_live_5yYYZlYIwY3LwvKFaXY0jNlm
 
 # datadog
 datadog_api_key: d3ab5d85bca924f9d4e33d307beacb4a


### PR DESCRIPTION
This moved a required CREAM env var to all.yml for all services. Runnable-web won't deploy without this.